### PR TITLE
Feat: pyrefly 설정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ temp/
 # pycache
 __pycache__/
 *.pyc
+
+# pyrefly
+pyrefly.toml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,3 +16,14 @@ repos:
       - id: ruff
         args: [--fix] # 자동 수정
       - id: ruff-format # 코드 포맷팅 (Black 대체)
+
+  # 마지막에 타입 검사 (코드 수정 후)
+  - repo: local
+    hooks:
+      - id: pyrefly
+        name: Pyrefly Type Check
+        entry: poetry run pyrefly check
+        language: system
+        files: ^src/.*\.py$
+        pass_filenames: false
+        stages: [commit] # commit 시에만 실행

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ pytest-asyncio = "^0.24.0"
 pre-commit = "^4.2.0"
 ruff = "^0.11.12"
 httpx = "^0.28.1"
+pyrefly = "^0.19.0"
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/src/users/models.py
+++ b/src/users/models.py
@@ -1,6 +1,8 @@
 import uuid
+from datetime import datetime
 
-from sqlalchemy import Boolean, Column, DateTime, String
+from sqlalchemy import Boolean, DateTime, String
+from sqlalchemy.orm import Mapped, mapped_column
 from sqlalchemy.sql import func
 
 from src.db.base import Base
@@ -14,13 +16,21 @@ class User(Base):
 
     __tablename__ = "users"
 
-    id = Column(String(36), primary_key=True, default=lambda: str(uuid.uuid4()))
-    email = Column(String(255), unique=True, index=True, nullable=False)
-    username = Column(String(50), unique=True, index=True, nullable=False)
-    hashed_password = Column(String(255), nullable=False)
-    profile_image_path = Column(String(255), nullable=True)
-    is_active = Column(Boolean, default=True)
-    created_at = Column(DateTime(timezone=True), server_default=func.now())
-    updated_at = Column(
+    id: Mapped[str] = mapped_column(
+        String(36), primary_key=True, default=lambda: str(uuid.uuid4())
+    )
+    email: Mapped[str] = mapped_column(
+        String(255), unique=True, index=True, nullable=False
+    )
+    username: Mapped[str] = mapped_column(
+        String(50), unique=True, index=True, nullable=False
+    )
+    hashed_password: Mapped[str] = mapped_column(String(255), nullable=False)
+    profile_image_path: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    is_active: Mapped[bool] = mapped_column(Boolean(), default=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
     )


### PR DESCRIPTION
이 PR은 유형 안전성을 강화하고 커밋 시 유형 검사를 강제 적용하며 SQLAlchemy 모델 정의를 현대화하기 위한 여러 변경 사항이 있으며, 가장 중요한 부분에는 유형 검사를 위한 새로운 pre-commit hook 추가, 의존성 업데이트를 통해 `pyrefly` 포함, `User` 모델을 SQLAlchemy 2.0 스타일 유형 주석 사용으로 리팩토링하는 것이 포함됩니다.

### Pre-commit 구성 업데이트:
* [`.pre-commit-config.yaml`](diffhunk://#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9R19-R29): `pyrefly`를 사용한 유형 검사를 위한 새로운 로컬 사전 커밋 훅을 추가했습니다. 이 훅은 커밋 시 실행되며 `src/` 디렉토리 내의 Python 파일을 검사합니다.

### Dependency 업데이트:
* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R28): `pyrefly`를 새로운 의존성으로 추가하고 버전 `^0.19.0`을 지정하여 유형 검사를 활성화했습니다.

### SQLAlchemy 모델 리팩토링:
* [`src/users/models.py`](diffhunk://#diff-427b34724e833389b229ff0ff0f0aee9819dc1b3f24eb4f2b1a27f05ac73b80dL17-R34): `User` 모델을 SQLAlchemy 2.0 스타일의 유형 주석(`Mapped` 및 `mapped_column`)을 사용하도록 리팩토링했습니다. 이는 유형 안전성을 향상시키고 현대적인 SQLAlchemy 관행과 일치합니다.

### import 변경 사항:
* [`src/users/models.py`](diffhunk://#diff-427b34724e833389b229ff0ff0f0aee9819dc1b3f24eb4f2b1a27f05ac73b80dR2-R5): `datetime`을 포함하도록 임포트 문장을 조정하고 `Column`의 중복 임포트를 제거했습니다.
